### PR TITLE
fix: rename url auth github

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,7 +28,7 @@ app.use(router);
 
 app.get("/github", (request, response) => {
   response.redirect(
-    `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}`
+    `https://github.com/login/oauth/authorize?scope=user&client_id=${process.env.GITHUB_CLIENT_ID}`
   );
 });
 


### PR DESCRIPTION
Não sei se nessa meio tempo houve alteração de endereço, mas essa semana, ao realizar a NLW de React, agarrei nessa parte e analisando vi que mudou um trechinho da URL, ao fazer essa alteração voltou a funcionar normalmente.